### PR TITLE
[DO NOT MERGE YET] Point private-registry images at GHCR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ DATABASE-LOCAL-ACCESS.md
 # Private keys pulled out of Terraform state by scripts/staging.sh
 .ssh_key
 terraform/envs/*/.ssh_key
+
+# 1Password Connect credentials copy written by scripts/onepassword-connect.sh
+1password-credentials.json*

--- a/GHCR-MIGRATION.md
+++ b/GHCR-MIGRATION.md
@@ -10,16 +10,32 @@ you merge, not when the box happens to be up. So the registry CI pushes to has t
 be always-on, which meant Zot in production could never be part of an environment
 that spins down. GHCR is always available and needs no self-hosting.
 
+## The pull secret covers both registries
+
+`registry_dockerconfigjson` holds auths for **both** `zot.zachsexton.com` and
+`ghcr.io`:
+
+```json
+{"auths":{"zot.zachsexton.com":{"auth":"..."},"ghcr.io":{"auth":"..."}}}
+```
+
+A Docker config can carry many registries, so the same secret authenticates
+before and after the manifest flip. That removes the ordering constraint on the
+credential entirely — it can be rolled out first, and nothing breaks whichever
+registry the manifests currently name.
+
+What remains ordered is only the *image*: it has to exist in GHCR before the
+manifest points at it.
+
 ## The ordering trap
 
 `k8s/apps/base/` is shared by production and staging, and production's Argo CD
 self-heals from `master`. **The moment the image reference changes on `master`,
 production tries to pull from the new registry.** So:
 
-- if the image is not in GHCR yet → `ImagePullBackOff`
-- if the pull secret still holds Zot credentials → `no basic auth credentials`
-
-Either takes production down. The manifest change must land **last**.
+With the dual-registry secret above rolled out, the credential half of this is
+solved. What is left is the image: **if it is not in GHCR yet, production gets
+`ImagePullBackOff`.** The manifest change must land after the images exist.
 
 There is no way to stage this per-environment: the image reference lives in the
 shared base, so both environments cut over together.
@@ -28,7 +44,14 @@ shared base, so both environments cut over together.
 
 ### 1. Push images to GHCR first
 
-Merge the `ghcr-migration` branch in the app repos:
+Push and merge the `ghcr-migration` branch in the app repos. **Pushing these
+needs a token with the `workflow` scope** — neither the `gh` OAuth token nor the
+classic PAT in 1Password has it, so this cannot be done from an agent session:
+
+```bash
+gh auth refresh -s workflow      # then push
+```
+
 
 - `ztsexton/ballroom-competition-web` — `docker-push.yaml` and `update-deployment.yaml`
 - `ztsexton/ballroom-study-buddy` — `build-and-push.yml`
@@ -57,15 +80,16 @@ Production is **not** bootstrapped by Terraform (`bootstrap_cluster = false`), s
 nothing creates this for it. Its existing `zot-registry-credentials` secret holds
 Zot credentials.
 
-Keep the name and replace the contents — that avoids touching the
-`imagePullSecrets` reference in the shared base manifest, which would otherwise
-have to change for both environments at once:
+Keep the name and replace the contents with a config covering **both**
+registries. Because it still authenticates to Zot, this is safe to apply
+immediately — production keeps pulling from Zot until the manifest changes, and
+then starts pulling from GHCR without a second change:
 
 ```bash
 # against the production cluster
 kubectl -n web create secret generic zot-registry-credentials \
   --type=kubernetes.io/dockerconfigjson \
-  --from-literal=.dockerconfigjson='{"auths":{"ghcr.io":{"auth":"<base64 of ztsexton:ghp_...>"}}}' \
+  --from-literal=.dockerconfigjson='{"auths":{"zot.zachsexton.com":{"auth":"<base64 admin:zot-pw>"},"ghcr.io":{"auth":"<base64 ztsexton:ghp_...>"}}}' \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
@@ -75,9 +99,9 @@ through the shared manifest before anything created the new name.
 
 ### 3. Staging already has it
 
-`registry_dockerconfigjson` in `terraform/envs/staging/terraform.tfvars` is
-already pointed at `ghcr.io`, and the bootstrap writes the secret on every
-rebuild. Re-run to apply:
+`registry_dockerconfigjson` in `terraform/envs/staging/terraform.tfvars` already
+carries both registries, and the bootstrap writes the secret on every rebuild.
+Re-run to apply:
 
 ```bash
 ./scripts/staging.sh up

--- a/GHCR-MIGRATION.md
+++ b/GHCR-MIGRATION.md
@@ -1,0 +1,117 @@
+# Migrating the private registry to GHCR
+
+Moving `ballroom-competition-web` and `ballroom-syllabi` off the self-hosted Zot
+registry onto `ghcr.io`.
+
+## Why
+
+A registry that spins down cannot be a CI push target — GitHub Actions runs when
+you merge, not when the box happens to be up. So the registry CI pushes to has to
+be always-on, which meant Zot in production could never be part of an environment
+that spins down. GHCR is always available and needs no self-hosting.
+
+## The ordering trap
+
+`k8s/apps/base/` is shared by production and staging, and production's Argo CD
+self-heals from `master`. **The moment the image reference changes on `master`,
+production tries to pull from the new registry.** So:
+
+- if the image is not in GHCR yet → `ImagePullBackOff`
+- if the pull secret still holds Zot credentials → `no basic auth credentials`
+
+Either takes production down. The manifest change must land **last**.
+
+There is no way to stage this per-environment: the image reference lives in the
+shared base, so both environments cut over together.
+
+## Order of operations
+
+### 1. Push images to GHCR first
+
+Merge the `ghcr-migration` branch in the app repos:
+
+- `ztsexton/ballroom-competition-web` — `docker-push.yaml` and `update-deployment.yaml`
+- `ztsexton/ballroom-study-buddy` — `build-and-push.yml`
+
+> `update-deployment.yaml` rewrites the image line in this repo automatically
+> once the build succeeds. Its replace matches **either** registry, so it is safe
+> whichever one the manifest currently points at — but it means merging the app
+> repo will move `master` here on its own. Do steps 2 and 3 first.
+
+Confirm the packages exist before going further:
+
+```bash
+PAT=<classic PAT with read:packages>
+BT=$(curl -sS -u ztsexton:$PAT \
+  "https://ghcr.io/token?service=ghcr.io&scope=repository:ztsexton/ballroom-competition-web:pull" \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])')
+curl -sS -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $BT" \
+  https://ghcr.io/v2/ztsexton/ballroom-competition-web/tags/list
+```
+
+`200` means the package is there and the credential can read it.
+
+### 2. Give production a GHCR pull secret
+
+Production is **not** bootstrapped by Terraform (`bootstrap_cluster = false`), so
+nothing creates this for it. Its existing `zot-registry-credentials` secret holds
+Zot credentials.
+
+Keep the name and replace the contents — that avoids touching the
+`imagePullSecrets` reference in the shared base manifest, which would otherwise
+have to change for both environments at once:
+
+```bash
+# against the production cluster
+kubectl -n web create secret generic zot-registry-credentials \
+  --type=kubernetes.io/dockerconfigjson \
+  --from-literal=.dockerconfigjson='{"auths":{"ghcr.io":{"auth":"<base64 of ztsexton:ghp_...>"}}}' \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+The secret keeps its Zot-era name until production is next rebuilt. Misleading,
+but renaming it now would break production, since the rename would reach it
+through the shared manifest before anything created the new name.
+
+### 3. Staging already has it
+
+`registry_dockerconfigjson` in `terraform/envs/staging/terraform.tfvars` is
+already pointed at `ghcr.io`, and the bootstrap writes the secret on every
+rebuild. Re-run to apply:
+
+```bash
+./scripts/staging.sh up
+```
+
+### 4. Merge the manifest change here
+
+Only once 1–3 are done. Then:
+
+```bash
+./scripts/staging.sh verify
+curl -sI https://petfoodfinder.app | head -1     # production
+```
+
+## Afterwards
+
+- Delete `ZOT_USERNAME` and `ZOT_PASSWORD` from both app repos' secrets
+- Remove Zot from the staging overlay: it holds nothing, uses `emptyDir`, and
+  only ever served an empty catalog. Production's Zot can stay until its images
+  are no longer referenced anywhere
+- Rotate the Zot admin password — it was pasted into a chat transcript during
+  this work
+
+## Notes
+
+**The pull credential must be a classic PAT.** Fine-grained tokens are documented
+as unsupported for GHCR pulls. Verified: a classic `ghp_` token exchanges for a
+bearer token that returns `200` on `/v2/`, where anonymous access returns
+`DENIED`.
+
+**`ghcr.io/v2/` returns 401 to basic auth even with valid credentials** — it uses
+bearer-token auth, so the token exchange is the only meaningful test.
+
+**`ballroom-syllabi` has never been in any registry.** The Zot catalog contained
+only `ballroom-competition-web`, which is why its deployment is pinned to a tag
+that does not exist and `syllabus.zachsexton.com` returns 404 in production
+today. Migrating it to GHCR is what will finally publish it.

--- a/STAGING-REBUILD.md
+++ b/STAGING-REBUILD.md
@@ -38,9 +38,14 @@ service accounts cannot create Connect servers.
 # into other shells
 eval $(op signin)
 
+./scripts/onepassword-connect.sh check     # must report "signed in"
 ./scripts/onepassword-connect.sh list      # read-only; shows production's server
 ./scripts/onepassword-connect.sh create personal-infra-staging Kubernetes,Kubernetes-Staging
 ```
+
+`check` tests `op whoami`, not `op account list` — the latter exits 0 for an
+account that is merely *added*, signed in or not, so it cannot detect a session.
+All three must run in the same shell as the `op signin`.
 
 Both vaults on purpose: every `OnePasswordItem` in the repo references
 `vaults/Kubernetes/...`, so a server scoped only to the staging vault resolves
@@ -141,7 +146,7 @@ registry — so these really are production's Zot admin credentials.
 
 Expected once steps 1–4 are done:
 
-```
+```text
 HOST                                       DNS      CODE   NOTE
 staging.zachsexton.com                     ok       200
 petfoodfinder-staging.zachsexton.com       ok       200

--- a/STAGING-REBUILD.md
+++ b/STAGING-REBUILD.md
@@ -1,0 +1,210 @@
+# Rebuilding staging from scratch
+
+How to destroy the staging VM and bring a new one back with
+`https://staging.petfoodfinder.app` serving a real response over a valid
+certificate.
+
+Steps 1 and 2 are one-time. After that the whole cycle is two commands.
+
+---
+
+## What has to be true for that URL to work
+
+Five things, in order. Four are automatic; one is not yet.
+
+| # | Requirement | Provided by | Automatic |
+| - | ----------- | ----------- | --------- |
+| 1 | `staging.petfoodfinder.app` resolves to the staging IP | Terraform `dns_records` | yes |
+| 2 | Traefik holds that IP as its LoadBalancer | MetalLB pool + Traefik values, pinned to the retained address | yes |
+| 3 | A trusted certificate for the host | cert-manager, using the Cloudflare token the bootstrap writes | yes |
+| 4 | An Ingress routing the host to the app | `k8s/apps/overlays/staging/ingress/ballroom-competition-web-ingress.yaml` | yes |
+| 5 | `ballroom-competition-web` actually running | needs `zot-registry-credentials` to pull from `zot.zachsexton.com` | **no — step 4 below** |
+
+Step 5 is the only reason that URL is currently a 404 rather than a 200.
+
+---
+
+## Step 1 — 1Password Connect credentials (one-time)
+
+Without these the operator never starts, `zot-auth` is never created, and step 4
+has nothing to derive a pull secret from.
+
+Requires an interactive 1Password sign-in and membership in a group with the
+**manage Secrets Automation** permission. A service account token will not work:
+service accounts cannot create Connect servers.
+
+```bash
+# in your own terminal -- the op session is an env var and does not survive
+# into other shells
+eval $(op signin)
+
+./scripts/onepassword-connect.sh list      # read-only; shows production's server
+./scripts/onepassword-connect.sh create personal-infra-staging Kubernetes,Kubernetes-Staging
+```
+
+Both vaults on purpose: every `OnePasswordItem` in the repo references
+`vaults/Kubernetes/...`, so a server scoped only to the staging vault resolves
+none of them.
+
+Creating a server is additive — production's Connect server, its credentials and
+its tokens are untouched, and vault access is granted per server.
+
+The script writes both values into `terraform/envs/staging/terraform.tfvars`
+(gitignored) and leaves a copy of the credentials file at
+`1password-credentials.json.KEEP-ME`.
+
+> **Put that copy in 1Password, then delete it.** A Connect server's credentials
+> file cannot be downloaded a second time. Lose it and the only recovery is
+> creating a new server.
+
+Verify:
+
+```bash
+grep -c '^onepassword_.* = "..*"' terraform/envs/staging/terraform.tfvars   # expect 2
+```
+
+## Step 2 — Confirm the address is protected (one-time)
+
+```bash
+./scripts/hcloud-primary-ip.sh list
+```
+
+`personal-staging-ipv4` must show `auto_delete=false`. That is what keeps the
+address across a destroy, which in turn keeps the DNS records and the IP
+hardcoded in the staging MetalLB pool and Traefik values valid — and is why
+`up` needs no manifest edit.
+
+If it ever shows `auto_delete=true`:
+
+```bash
+./scripts/hcloud-primary-ip.sh protect <that-ip>
+```
+
+---
+
+## Step 3 — Destroy and recreate
+
+```bash
+./scripts/staging.sh down     # ~30s
+./scripts/staging.sh up       # ~4 min
+```
+
+`down` is a targeted destroy of the server. A plain `terraform destroy` fails on
+the primary IP's `prevent_destroy`. The DNS records go with the server and are
+recreated by `up` against the same address, so they come back identical.
+
+`up` allocates the address if needed, checks the manifests point at it, builds
+the server, runs the bootstrap (k3s → 1Password secrets → Cloudflare token →
+Argo CD → root Application), waits for Argo CD to work through sync waves −1..2,
+then runs `verify`.
+
+It is safe to re-run. If only the tfvars changed, it re-runs the bootstrap
+(~90s) without touching the server.
+
+## Step 4 — Create the registry pull secret
+
+The one manual step. `zot-registry-credentials` is **not** a 1Password item — it
+is derived from `zot-auth`, which only exists once the operator has synced it,
+which happens after the bootstrap has already finished. So it cannot be another
+line in the bootstrap script.
+
+```bash
+export KUBECONFIG=$PWD/kubeconfig-staging.yaml
+
+# wait for the operator to sync zot-auth
+kubectl -n web get secret zot-auth
+
+ZOT_PW=$(kubectl -n web get secret zot-auth -o jsonpath='{.data.password}' \
+  | base64 -d | cut -d: -f2)
+
+kubectl -n web create secret docker-registry zot-registry-credentials \
+  --docker-server=zot.zachsexton.com \
+  --docker-username=admin \
+  --docker-password="$ZOT_PW" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n web delete pod -l app=ballroom-competition-web   # retry the pull
+```
+
+Staging pulls `zot.zachsexton.com/ballroom-competition-web` — the **production**
+registry — so these really are production's Zot admin credentials.
+
+> This does not survive a spin-down and must be repeated after every `up`. It can
+> be folded into the bootstrap as an opportunistic wait-and-derive; see
+> *Automating step 4* below.
+
+## Step 5 — Verify
+
+```bash
+./scripts/staging.sh verify
+```
+
+Expected once steps 1–4 are done:
+
+```
+HOST                                       DNS      CODE   NOTE
+staging.zachsexton.com                     ok       200
+petfoodfinder-staging.zachsexton.com       ok       200
+vigilo-staging.zachsexton.com              ok       200
+spotifybutler-staging.zachsexton.com       ok       200
+staging.petfoodfinder.app                  ok       200
+syllabus-staging.zachsexton.com            ok       200
+zot-staging.zachsexton.com                 ok       200   (auth required -- serving)
+grafana-staging.zachsexton.com             ok       302
+argocd-staging.zachsexton.com              ok       200
+```
+
+`verify` deliberately does **not** pass `-k`. A self-signed certificate counts as
+a failure, because that is exactly what happens when cert-manager cannot solve
+the DNS01 challenge — and it is easy to miss otherwise.
+
+The direct check for the host you care about:
+
+```bash
+curl -sI https://staging.petfoodfinder.app | head -1
+```
+
+---
+
+## When it does not come up
+
+`verify` names the pod behind each failing host and its last Warning event. The
+common ones:
+
+| Symptom | Cause | Fix |
+| ------- | ----- | --- |
+| `ImagePullBackOff` / `zot-registry-credentials` | step 4 not done, or redone after a rebuild | step 4 |
+| `ContainerCreating` / `zot-auth not found` | 1Password operator not running | step 1, then `./scripts/staging.sh up` |
+| every host fails TLS | cert-manager has no Cloudflare token | check `cloudflare_api_token` is set in the tfvars, then `up` |
+| certificates stuck `READY=False` | stale ACME challenges from before the token existed | `kubectl -n web delete challenge,order,certificaterequest --all` |
+| `argocd-staging` returns 502 | the ingress is on port 443 | must be port 80: the bootstrap sets `server.insecure`, so argocd-server speaks plain HTTP |
+| Traefik LoadBalancer stuck `<pending>` | MetalLB pool does not match the real address | `./scripts/set-env-ip.sh staging <ip>`, commit, push |
+
+Useful:
+
+```bash
+./scripts/staging.sh status
+./scripts/staging.sh ssh
+./scripts/staging.sh kubeconfig
+kubectl -n argocd get applications
+```
+
+---
+
+## Automating step 4
+
+Step 4 is the only thing keeping this from being a genuine two-command rebuild.
+It can be closed by having the bootstrap, after applying the root Application,
+poll for `zot-auth` for a few minutes and derive the pull secret if it appears —
+non-fatal, so a slow or failed sync does not fail the apply.
+
+The alternative is an in-cluster Job in the staging manifests that watches for
+`zot-auth`. More GitOps-native, does not slow `up`, more moving parts.
+
+Neither is implemented yet.
+
+## Cost
+
+A `cpx21` is roughly EUR 8/month; an unassigned primary IPv4 is roughly EUR 0.60.
+`down` therefore saves over 90% while keeping the address, and the whole point of
+keeping it is that `up` stays a single command.

--- a/STAGING-REBUILD.md
+++ b/STAGING-REBUILD.md
@@ -108,35 +108,55 @@ It is safe to re-run. If only the tfvars changed, it re-runs the bootstrap
 
 ## Step 4 — Create the registry pull secret
 
-The one manual step. `zot-registry-credentials` is **not** a 1Password item — it
-is derived from `zot-auth`, which only exists once the operator has synced it,
-which happens after the bootstrap has already finished. So it cannot be another
-line in the bootstrap script.
+The one manual step, and the one that needs a value this repo does not hold.
+
+`ballroom-competition-web` and `ballroom-syllabi` pull from
+`zot.zachsexton.com` — the **production** registry — and fail with:
+
+```text
+pull access denied ... authorization failed: no basic auth credentials
+```
+
+`zot-registry-credentials` is not a 1Password item. It has to be built from the
+Zot admin username and password:
 
 ```bash
 export KUBECONFIG=$PWD/kubeconfig-staging.yaml
 
-# wait for the operator to sync zot-auth
-kubectl -n web get secret zot-auth
-
-ZOT_PW=$(kubectl -n web get secret zot-auth -o jsonpath='{.data.password}' \
-  | base64 -d | cut -d: -f2)
-
 kubectl -n web create secret docker-registry zot-registry-credentials \
   --docker-server=zot.zachsexton.com \
   --docker-username=admin \
-  --docker-password="$ZOT_PW" \
+  --docker-password='<the plaintext Zot admin password>' \
   --dry-run=client -o yaml | kubectl apply -f -
 
-kubectl -n web delete pod -l app=ballroom-competition-web   # retry the pull
+kubectl -n web delete pod -l app=ballroom-competition-web
+kubectl -n web delete pod -l app=ballroom-syllabi
 ```
 
-Staging pulls `zot.zachsexton.com/ballroom-competition-web` — the **production**
-registry — so these really are production's Zot admin credentials.
+### Why it cannot be derived from `zot-auth`
 
-> This does not survive a spin-down and must be repeated after every `up`. It can
-> be folded into the bootstrap as an opportunistic wait-and-derive; see
-> *Automating step 4* below.
+`scripts/setup-zot-registry-credentials.sh` and
+`k8s/apps/base/ballroom-competition-web/README.md` both say to take the password
+from the `zot-auth` secret:
+
+```bash
+# WRONG -- this yields a bcrypt hash, not a password
+kubectl -n web get secret zot-auth -o jsonpath='{.data.password}' | base64 -d | cut -d: -f2
+```
+
+`zot-auth` is synced from `vaults/Kubernetes/items/zot-htpasswd` and holds an
+**htpasswd line**: `admin:$2y$...`. Field 2 is the bcrypt hash Zot checks
+passwords against, not a password — feeding it to `--docker-password` produces a
+secret that always fails authentication.
+
+The plaintext exists only wherever it was originally set. If it is not in
+1Password, the alternative is to rotate it: generate a new password, regenerate
+the htpasswd entry (`scripts/setup-zot-auth.sh`), update the `zot-htpasswd` item,
+and recreate this secret. **That rotates production's registry credentials too**,
+since both environments read the same 1Password item.
+
+> Like the rest of this step, the secret does not survive a spin-down and must be
+> recreated after every `up`.
 
 ## Step 5 — Verify
 

--- a/k8s/apps/base/ballroom-competition-web/deployment.yaml
+++ b/k8s/apps/base/ballroom-competition-web/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: zot.zachsexton.com/ballroom-competition-web:master-8c5c037
+          image: ghcr.io/ztsexton/ballroom-competition-web:master-8c5c037
           imagePullPolicy: Always
           env:
             - name: PORT

--- a/k8s/apps/base/ballroom-syllabi/deployment.yaml
+++ b/k8s/apps/base/ballroom-syllabi/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: zot.zachsexton.com/ballroom-syllabi:main-389428c
+          image: ghcr.io/ztsexton/ballroom-syllabi:main-389428c
           imagePullPolicy: Always
           env:
             - name: PORT

--- a/scripts/onepassword-connect.sh
+++ b/scripts/onepassword-connect.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Put 1Password Connect credentials into an environment's terraform.tfvars.
+#
+#   ./scripts/onepassword-connect.sh check
+#   ./scripts/onepassword-connect.sh create [server-name] [vault]
+#   ./scripts/onepassword-connect.sh import <credentials.json> <token>
+#
+# `create` makes a NEW Connect server and token and writes both into the tfvars.
+# `import` takes a credentials file and token you already have -- use this if the
+# pair is already saved in 1Password, since **the credentials file cannot be
+# re-downloaded** once the Connect server has been created.
+#
+# Creating a Connect server needs an interactive 1Password sign-in and membership
+# in a group with the "manage Secrets Automation" permission. A service account
+# token is not sufficient: service accounts cannot create Connect servers.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+ENVIRONMENT="${ENVIRONMENT:-staging}"
+TFVARS="$REPO/terraform/envs/$ENVIRONMENT/terraform.tfvars"
+export PATH="$HOME/bin:$PATH"
+
+red()   { printf '\033[0;31m%s\033[0m\n' "$*" >&2; }
+green() { printf '\033[0;32m%s\033[0m\n' "$*"; }
+warn()  { printf '\033[1;33m%s\033[0m\n' "$*"; }
+step()  { printf '\033[1;36m==> %s\033[0m\n' "$*"; }
+die()   { red "error: $*"; exit 1; }
+
+need_op() {
+  command -v op >/dev/null || die "the 1Password CLI is not on PATH (installed at ~/bin/op)"
+}
+
+cmd_check() {
+  need_op
+  echo "op version : $(op --version)"
+  echo "tfvars     : $TFVARS"
+  echo
+  if op account list 2>/dev/null | grep -q .; then
+    green "signed in:"
+    op account list
+  else
+    warn "not signed in. Either:"
+    warn "  - turn on the desktop app integration, or"
+    warn "  - op account add --address <team>.1password.com --email <you>"
+    warn '    then: eval $(op signin)' 
+    return 1
+  fi
+}
+
+# HCL interpolates \${...} even inside heredocs, so any literal \${ in the value
+# has to be escaped or Terraform will try to evaluate it.
+write_var() { # name value
+  TFVARS="$TFVARS" VNAME="$1" VVALUE="$2" python3 - <<'PY'
+import json, os, re
+p, n, v = os.environ["TFVARS"], os.environ["VNAME"], os.environ["VVALUE"]
+v = v.replace("${", "$${")
+s = open(p).read()
+line = "%s = %s" % (n, json.dumps(v))
+if re.search(r"^%s\s*=" % re.escape(n), s, re.M):
+    s = re.sub(r"^%s\s*=.*$" % re.escape(n), line, s, count=1, flags=re.M)
+else:
+    s = s.rstrip("\n") + "\n" + line + "\n"
+open(p, "w").write(s)
+PY
+}
+
+validate_credentials() { # file
+  python3 - "$1" <<'PY'
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception as e:
+    sys.exit("not valid JSON: %s" % e)
+missing = [k for k in ("verifier", "encCredentials", "uniqueKey") if k not in d]
+if missing:
+    sys.exit("does not look like 1password-credentials.json (missing %s)" % ", ".join(missing))
+print("credentials file looks valid")
+PY
+}
+
+cmd_create() {
+  need_op
+  cmd_check >/dev/null || die "sign in first: ./scripts/onepassword-connect.sh check"
+
+  local server="${1:-personal-infra-$ENVIRONMENT}"
+  local vault="${2:-Kubernetes}"
+  local token_name="$server-token"
+  local workdir
+  workdir=$(mktemp -d)
+
+  step "creating Connect server '$server' with access to vault '$vault'"
+  warn "The credentials file cannot be downloaded again. It is saved into the"
+  warn "gitignored tfvars below -- also store it in 1Password."
+
+  ( cd "$workdir" && op connect server create "$server" --vaults "$vault" ) \
+    || die "could not create the Connect server (needs 'manage Secrets Automation')"
+
+  local credfile="$workdir/1password-credentials.json"
+  [ -f "$credfile" ] || die "op did not produce 1password-credentials.json"
+  validate_credentials "$credfile"
+
+  step "creating a Connect token"
+  local token
+  token=$(op connect token create "$token_name" --server "$server" --vault "$vault") \
+    || die "could not create the Connect token"
+  [ -n "$token" ] || die "the token came back empty"
+
+  write_var onepassword_credentials_json "$(cat "$credfile")"
+  write_var onepassword_connect_token "$token"
+
+  cp "$credfile" "$REPO/1password-credentials.json.KEEP-ME"
+  chmod 600 "$REPO/1password-credentials.json.KEEP-ME"
+  rm -rf "$workdir"
+
+  echo
+  green "wrote both values into $TFVARS"
+  warn  "a copy of the credentials file is at 1password-credentials.json.KEEP-ME"
+  warn  "-- put it in 1Password, then delete it. It cannot be regenerated."
+  echo
+  echo "next:  ./scripts/${ENVIRONMENT}.sh up      # re-runs only the bootstrap"
+}
+
+cmd_import() {
+  local credfile="${1:-}" token="${2:-}"
+  [ -f "$credfile" ] || die "usage: $0 import <credentials.json> <token>"
+  [ -n "$token" ]    || die "usage: $0 import <credentials.json> <token>"
+  validate_credentials "$credfile"
+
+  write_var onepassword_credentials_json "$(cat "$credfile")"
+  write_var onepassword_connect_token "$token"
+  green "wrote both values into $TFVARS"
+  echo "next:  ./scripts/${ENVIRONMENT}.sh up"
+}
+
+case "${1:-}" in
+  check)  cmd_check ;;
+  create) shift; cmd_create "$@" ;;
+  import) shift; cmd_import "$@" ;;
+  *)
+    cat >&2 <<EOF
+usage: $0 <command>
+
+  check                              is op installed and signed in
+  create [server-name] [vault]       new Connect server + token -> tfvars
+  import <credentials.json> <token>  use a pair you already have
+
+Environment: $ENVIRONMENT  (override with ENVIRONMENT=sandbox)
+EOF
+    exit 1 ;;
+esac

--- a/scripts/onepassword-connect.sh
+++ b/scripts/onepassword-connect.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Put 1Password Connect credentials into an environment's terraform.tfvars.
 #
+#   ./scripts/onepassword-connect.sh list
 #   ./scripts/onepassword-connect.sh check
 #   ./scripts/onepassword-connect.sh create [server-name] [vault]
 #   ./scripts/onepassword-connect.sh import <credentials.json> <token>
@@ -78,9 +79,25 @@ print("credentials file looks valid")
 PY
 }
 
+cmd_list() {
+  need_op
+  step "Connect servers on this account"
+  op connect server list 2>&1
+  echo
+  echo "Servers are independent: creating one does not touch another's"
+  echo "credentials or tokens, and vault access is granted per server"
+  echo "(revoking is a separate 'op connect vault revoke')."
+}
+
 cmd_create() {
   need_op
   cmd_check >/dev/null || die "sign in first: ./scripts/onepassword-connect.sh check"
+
+  # Show what already exists, so it is obvious this is additive and that
+  # production's Connect server is left alone.
+  step "Connect servers that already exist (these are not modified)"
+  op connect server list 2>&1 | sed 's/^/  /'
+  echo
 
   local server="${1:-personal-infra-$ENVIRONMENT}"
   # Comma-separated. The repo's OnePasswordItem CRs all reference
@@ -147,6 +164,7 @@ cmd_import() {
 }
 
 case "${1:-}" in
+  list)   cmd_list ;;
   check)  cmd_check ;;
   create) shift; cmd_create "$@" ;;
   import) shift; cmd_import "$@" ;;
@@ -154,6 +172,7 @@ case "${1:-}" in
     cat >&2 <<EOF
 usage: $0 <command>
 
+  list                               existing Connect servers (read-only)
   check                              is op installed and signed in
   create [server-name] [vaults]      new Connect server + token -> tfvars
                                      vaults is comma-separated;

--- a/scripts/onepassword-connect.sh
+++ b/scripts/onepassword-connect.sh
@@ -36,16 +36,21 @@ cmd_check() {
   echo "op version : $(op --version)"
   echo "tfvars     : $TFVARS"
   echo
-  if op account list 2>/dev/null | grep -q .; then
+  # `op account list` exits 0 for a merely ADDED account, signed in or not, so it
+  # cannot be used to test for a session. `op whoami` needs a live one.
+  if op whoami >/dev/null 2>&1; then
     green "signed in:"
-    op account list
-  else
-    warn "not signed in. Either:"
-    warn "  - turn on the desktop app integration, or"
-    warn "  - op account add --address <team>.1password.com --email <you>"
-    warn '    then: eval $(op signin)' 
-    return 1
+    op whoami
+    return 0
   fi
+
+  warn "an account is configured but there is no active session:"
+  op account list 2>/dev/null | sed 's/^/  /'
+  echo
+  warn "sign in, then run create IN THE SAME SHELL -- the session is an env var"
+  warn "and does not survive into another process:"
+  warn "    eval \$(op signin)"
+  return 1
 }
 
 # HCL interpolates \${...} even inside heredocs, so any literal \${ in the value
@@ -94,9 +99,9 @@ cmd_create() {
   cmd_check >/dev/null || die "sign in first: ./scripts/onepassword-connect.sh check"
 
   # Show what already exists, so it is obvious this is additive and that
-  # production's Connect server is left alone.
+  # production's Connect server is left alone. Never fatal.
   step "Connect servers that already exist (these are not modified)"
-  op connect server list 2>&1 | sed 's/^/  /'
+  op connect server list 2>&1 | sed 's/^/  /' || true
   echo
 
   local server="${1:-personal-infra-$ENVIRONMENT}"
@@ -112,8 +117,19 @@ cmd_create() {
   warn "The credentials file cannot be downloaded again. It is saved into the"
   warn "gitignored tfvars below -- also store it in 1Password."
 
-  ( cd "$workdir" && op connect server create "$server" --vaults "$vaults" ) \
-    || die "could not create the Connect server (needs 'manage Secrets Automation')"
+  local err
+  err="$workdir/create.err"
+  if ! ( cd "$workdir" && op connect server create "$server" --vaults "$vaults" 2>"$err" ); then
+    red "op could not create the Connect server:"
+    sed 's/^/  /' "$err" >&2
+    echo >&2
+    warn "common causes:"
+    warn "  - no active session in THIS shell      -> eval \$(op signin)"
+    warn "  - a vault name does not match exactly  -> op vault list"
+    warn "  - your account lacks the 'manage Secrets Automation' permission"
+    warn "  - a server called '$server' already exists -> $0 list"
+    exit 1
+  fi
 
   local credfile="$workdir/1password-credentials.json"
   [ -f "$credfile" ] || die "op did not produce 1password-credentials.json"

--- a/scripts/onepassword-connect.sh
+++ b/scripts/onepassword-connect.sh
@@ -83,26 +83,40 @@ cmd_create() {
   cmd_check >/dev/null || die "sign in first: ./scripts/onepassword-connect.sh check"
 
   local server="${1:-personal-infra-$ENVIRONMENT}"
-  local vault="${2:-Kubernetes}"
+  # Comma-separated. The repo's OnePasswordItem CRs all reference
+  # vaults/Kubernetes/..., so a server scoped only to a staging vault resolves
+  # none of them.
+  local vaults="${2:-Kubernetes,Kubernetes-Staging}"
   local token_name="$server-token"
   local workdir
   workdir=$(mktemp -d)
 
-  step "creating Connect server '$server' with access to vault '$vault'"
+  step "creating Connect server '$server' with access to: $vaults"
   warn "The credentials file cannot be downloaded again. It is saved into the"
   warn "gitignored tfvars below -- also store it in 1Password."
 
-  ( cd "$workdir" && op connect server create "$server" --vaults "$vault" ) \
+  ( cd "$workdir" && op connect server create "$server" --vaults "$vaults" ) \
     || die "could not create the Connect server (needs 'manage Secrets Automation')"
 
   local credfile="$workdir/1password-credentials.json"
   [ -f "$credfile" ] || die "op did not produce 1password-credentials.json"
   validate_credentials "$credfile"
 
-  step "creating a Connect token"
+  step "creating a read-only Connect token"
+  # The operator only ever reads, so the token is scoped read-only per vault
+  # (",r"). If that form is rejected, fall back to inheriting the server's
+  # permissions rather than failing the whole run.
+  local vaultargs=() v
+  IFS=',' read -ra _vs <<<"$vaults"
+  for v in "${_vs[@]}"; do vaultargs+=(--vaults "$v,r"); done
+
   local token
-  token=$(op connect token create "$token_name" --server "$server" --vault "$vault") \
-    || die "could not create the Connect token"
+  token=$(op connect token create "$token_name" --server "$server" "${vaultargs[@]}" 2>/dev/null) || token=""
+  if [ -z "$token" ]; then
+    warn "read-only scoping was rejected; issuing a token with the server's permissions"
+    token=$(op connect token create "$token_name" --server "$server") \
+      || die "could not create the Connect token"
+  fi
   [ -n "$token" ] || die "the token came back empty"
 
   write_var onepassword_credentials_json "$(cat "$credfile")"
@@ -141,7 +155,9 @@ case "${1:-}" in
 usage: $0 <command>
 
   check                              is op installed and signed in
-  create [server-name] [vault]       new Connect server + token -> tfvars
+  create [server-name] [vaults]      new Connect server + token -> tfvars
+                                     vaults is comma-separated;
+                                     default: Kubernetes,Kubernetes-Staging
   import <credentials.json> <token>  use a pair you already have
 
 Environment: $ENVIRONMENT  (override with ENVIRONMENT=sandbox)

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -353,6 +353,23 @@ derives record content from a conditional naming both the primary IP and the
 server, and Terraform builds its dependency graph from every reference in an
 expression rather than from the branch that evaluates.
 
+#### Getting the 1Password credentials
+
+```bash
+./scripts/onepassword-connect.sh check     # is op installed and signed in
+./scripts/onepassword-connect.sh create    # new Connect server + token -> tfvars
+./scripts/onepassword-connect.sh import <credentials.json> <token>
+```
+
+Creating a Connect server needs an interactive 1Password sign-in and membership
+in a group with the **manage Secrets Automation** permission. A service account
+token will not do: service accounts cannot create Connect servers. So this step
+cannot be automated end to end without a human session.
+
+Use `import` if the pair is already saved in 1Password — **the credentials file
+cannot be downloaded again** once its Connect server exists, so `create` issues a
+new server rather than recovering the old one.
+
 #### What needs 1Password
 
 Without `onepassword_connect_token` and `onepassword_credentials_json`, the

--- a/terraform/envs/sandbox/main.tf
+++ b/terraform/envs/sandbox/main.tf
@@ -38,8 +38,9 @@ module "env" {
   ssh_key_ids        = [hcloud_ssh_key.this.id]
   ssh_private_key    = tls_private_key.this.private_key_openssh
 
-  k3s_token            = var.k3s_token
-  cloudflare_api_token = var.cloudflare_api_token
+  k3s_token                 = var.k3s_token
+  cloudflare_api_token      = var.cloudflare_api_token
+  registry_dockerconfigjson = var.registry_dockerconfigjson
 
   bootstrap_cluster            = var.bootstrap_cluster
   argocd_admin_password_bcrypt = var.argocd_admin_password_bcrypt

--- a/terraform/envs/sandbox/variables.tf
+++ b/terraform/envs/sandbox/variables.tf
@@ -50,6 +50,13 @@ variable "onepassword_credentials_json" {
   default     = ""
 }
 
+variable "registry_dockerconfigjson" {
+  description = "Docker config JSON for the private registry. Becomes the zot-registry-credentials pull secret."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 # --- Cloudflare zones ---------------------------------------------------------
 
 variable "cloudflare_zone_id_zachsexton" {

--- a/terraform/envs/staging/main.tf
+++ b/terraform/envs/staging/main.tf
@@ -30,8 +30,9 @@ module "env" {
   ssh_key_ids     = [hcloud_ssh_key.this.id]
   ssh_private_key = tls_private_key.this.private_key_openssh
 
-  k3s_token            = var.k3s_token
-  cloudflare_api_token = var.cloudflare_api_token
+  k3s_token                 = var.k3s_token
+  cloudflare_api_token      = var.cloudflare_api_token
+  registry_dockerconfigjson = var.registry_dockerconfigjson
 
   argocd_admin_password_bcrypt = var.argocd_admin_password_bcrypt
   git_root_app_path            = "k8s/argocd/staging"

--- a/terraform/envs/staging/variables.tf
+++ b/terraform/envs/staging/variables.tf
@@ -50,6 +50,13 @@ variable "onepassword_credentials_json" {
   default     = ""
 }
 
+variable "registry_dockerconfigjson" {
+  description = "Docker config JSON for the private registry. Becomes the zot-registry-credentials pull secret."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 # --- Cloudflare zones ---------------------------------------------------------
 
 variable "cloudflare_zone_id_zachsexton" {

--- a/terraform/modules/environment/bootstrap.tf
+++ b/terraform/modules/environment/bootstrap.tf
@@ -108,7 +108,7 @@ resource "null_resource" "cluster_bootstrap" {
           echo "cluster bootstrap failed (exit $rc); last 100 log lines:"
           tail -n 100 /var/log/cluster-bootstrap.log
         fi
-        secrets="/root/bootstrap/op-connect-token /root/bootstrap/1password-credentials.json /root/bootstrap/cloudflare-api-token"
+        secrets="/root/bootstrap/op-connect-token /root/bootstrap/1password-credentials.json /root/bootstrap/op-creds.b64 /root/bootstrap/cloudflare-api-token"
         shred -u $secrets 2>/dev/null || rm -f $secrets
         exit $rc
       EOT

--- a/terraform/modules/environment/bootstrap.tf
+++ b/terraform/modules/environment/bootstrap.tf
@@ -12,11 +12,13 @@ locals {
   })
 
   bootstrap_cloudflare_token = var.cloudflare_api_token != ""
+  bootstrap_registry_auth    = var.registry_dockerconfigjson != ""
 
   bootstrap_script = templatefile("${path.module}/templates/bootstrap-cluster.sh.tmpl", {
     argocd_chart_version       = var.argocd_chart_version
     bootstrap_onepassword      = local.bootstrap_onepassword
     bootstrap_cloudflare_token = local.bootstrap_cloudflare_token
+    bootstrap_registry_auth    = local.bootstrap_registry_auth
     git_repo_url               = var.git_repo_url
     git_root_app_path          = var.git_root_app_path
     git_revision               = var.git_revision
@@ -40,6 +42,7 @@ resource "null_resource" "cluster_bootstrap" {
     root_app_sha   = sha256(local.root_app)
     op_secrets_sha = nonsensitive(sha256("${var.onepassword_connect_token}:${var.onepassword_credentials_json}"))
     cf_token_sha   = nonsensitive(sha256(var.cloudflare_api_token))
+    registry_sha   = nonsensitive(sha256(var.registry_dockerconfigjson))
   }
 
   connection {
@@ -89,6 +92,11 @@ resource "null_resource" "cluster_bootstrap" {
     destination = "/root/bootstrap/cloudflare-api-token"
   }
 
+  provisioner "file" {
+    content     = local.bootstrap_registry_auth ? var.registry_dockerconfigjson : "unused"
+    destination = "/root/bootstrap/registry-dockerconfig.json"
+  }
+
   provisioner "remote-exec" {
     inline = [
       "chmod 0600 /root/bootstrap/*",
@@ -108,7 +116,7 @@ resource "null_resource" "cluster_bootstrap" {
           echo "cluster bootstrap failed (exit $rc); last 100 log lines:"
           tail -n 100 /var/log/cluster-bootstrap.log
         fi
-        secrets="/root/bootstrap/op-connect-token /root/bootstrap/1password-credentials.json /root/bootstrap/op-creds.b64 /root/bootstrap/cloudflare-api-token"
+        secrets="/root/bootstrap/op-connect-token /root/bootstrap/1password-credentials.json /root/bootstrap/op-creds.b64 /root/bootstrap/cloudflare-api-token /root/bootstrap/registry-dockerconfig.json"
         shred -u $secrets 2>/dev/null || rm -f $secrets
         exit $rc
       EOT

--- a/terraform/modules/environment/templates/bootstrap-cluster.sh.tmpl
+++ b/terraform/modules/environment/templates/bootstrap-cluster.sh.tmpl
@@ -71,6 +71,21 @@ log "WARNING: no Cloudflare token supplied; cert-manager cannot solve DNS01 and"
 log "         no TLS certificate will be issued."
 %{ endif ~}
 
+# --- 1c. private registry pull secret -----------------------------------------
+# Not a OnePasswordItem, and it cannot be derived from zot-auth: that secret
+# holds an htpasswd line (admin:$2y$...), whose second field is the bcrypt hash
+# Zot checks against, not a usable password. So the docker config is supplied
+# directly and recreated on every bootstrap, which is what keeps a spun-down
+# environment coming back able to pull.
+%{ if bootstrap_registry_auth ~}
+log "Creating the private registry pull secret"
+kubectl create namespace web --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n web create secret generic zot-registry-credentials   --type=kubernetes.io/dockerconfigjson   --from-file=.dockerconfigjson="$BOOTSTRAP_DIR/registry-dockerconfig.json"   --dry-run=client -o yaml | kubectl apply -f -
+%{ else ~}
+log "WARNING: no registry credentials supplied; images from the private registry"
+log "         will fail with 'no basic auth credentials'."
+%{ endif ~}
+
 # --- 2. Argo CD ---------------------------------------------------------------
 log "Installing Argo CD (argo-cd chart ${argocd_chart_version})"
 helm repo add argo https://argoproj.github.io/argo-helm >/dev/null

--- a/terraform/modules/environment/templates/bootstrap-cluster.sh.tmpl
+++ b/terraform/modules/environment/templates/bootstrap-cluster.sh.tmpl
@@ -36,8 +36,16 @@ kubectl -n onepassword create secret generic onepassword-token \
   --from-literal=token="$(cat "$BOOTSTRAP_DIR/op-connect-token")" \
   --dry-run=client -o yaml | kubectl apply -f -
 
+# Connect does not read this file as JSON: it base64-decodes it first, so the
+# secret has to hold BASE64-ENCODED JSON. Handing it the raw file produces
+#   LoadLocalAuthV2 failed to credentialsDataFromBase64,
+#   illegal base64 data at input byte 0
+# and connect-sync then retries forever while every OnePasswordItem fails with
+# "failed to GetVaultsByTitle ... status 500: failed to initiate".
+base64 -w0 "$BOOTSTRAP_DIR/1password-credentials.json" > "$BOOTSTRAP_DIR/op-creds.b64"
+
 kubectl -n onepassword create secret generic op-credentials \
-  --from-file=1password-credentials.json="$BOOTSTRAP_DIR/1password-credentials.json" \
+  --from-file=1password-credentials.json="$BOOTSTRAP_DIR/op-creds.b64" \
   --dry-run=client -o yaml | kubectl apply -f -
 %{ else ~}
 log "WARNING: 1Password Connect credentials not supplied; skipping."

--- a/terraform/modules/environment/variables.tf
+++ b/terraform/modules/environment/variables.tf
@@ -132,6 +132,13 @@ variable "cloudflare_api_token" {
   default     = ""
 }
 
+variable "registry_dockerconfigjson" {
+  description = "Docker config JSON for the private registry, e.g. {\"auths\":{\"host\":{\"auth\":\"<base64 user:pass>\"}}}. Becomes the zot-registry-credentials pull secret. Cannot be derived from zot-auth, which holds an htpasswd line rather than a password. Empty skips it and private images will not pull."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 # --- DNS ----------------------------------------------------------------------
 
 variable "cloudflare_zone_ids" {


### PR DESCRIPTION
Draft on purpose. See `GHCR-MIGRATION.md` — this must land **last**.

## Why it is dangerous to merge early

`k8s/apps/base/` is shared by production and staging, and production's Argo CD self-heals from `master`. The moment the image reference changes here, **production pulls from the new registry**:

- image not in GHCR yet → `ImagePullBackOff`
- pull secret still holds Zot credentials → `no basic auth credentials`

Either takes production down. There is no per-environment staging of this — the image reference lives in the shared base, so both environments cut over together.

## Order

1. Merge `ghcr-migration` in `ztsexton/ballroom-competition-web` and `ztsexton/ballroom-study-buddy` so the packages exist
2. Replace production's `zot-registry-credentials` contents with a GHCR dockerconfigjson (production is not bootstrapped by Terraform, so nothing creates it there)
3. `./scripts/staging.sh up` — staging's `registry_dockerconfigjson` already points at ghcr.io
4. Merge this

## What changed

`ballroom-competition-web` and `ballroom-syllabi` now reference `ghcr.io/ztsexton/<image>`.

`imagePullSecrets` deliberately keeps the name `zot-registry-credentials`. The name is wrong now, but renaming it would reach production through the shared manifest before anything created the new name. Production swaps the secret's *contents* instead; the rename waits for its next rebuild.

## Verified along the way

- A classic `ghp_` PAT exchanges for a bearer token that returns `200` on `/v2/`, where anonymous returns `DENIED`. Fine-grained tokens are documented as unsupported for GHCR pulls.
- `ghcr.io/v2/` returns 401 to basic auth **even with valid credentials** — it uses bearer-token auth, so the token exchange is the only meaningful test. An earlier conclusion of mine based on the basic-auth response was wrong.
- The `update-deployment.yaml` replace matches either registry, tested against both forms. Its delimiter is `#` rather than `|`, because the alternation contains `|`.

## Note

`ballroom-syllabi` has never been in any registry — the Zot catalog held only `ballroom-competition-web`. That is why its deployment is pinned to a nonexistent tag and `syllabus.zachsexton.com` 404s in production today. This migration is what will finally publish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PF7JngZh28GPY8dn5nw2iT